### PR TITLE
Parse IRC messages using an approach based on python's twisted module

### DIFF
--- a/node-irc/irc.js
+++ b/node-irc/irc.js
@@ -794,10 +794,10 @@ function parseMessage(line, stripColors) { // {{{
     if ((pos = line.indexOf(' :')) !== -1) {
         trailing = line.substr(pos + 2);
         line     = line.substr(0, pos);
-        args     = line.split(' ');
+        args     = line.length != 0 ? line.split(' ') : [];
         args.push(trailing);
     } else {
-        args = line.split(' ');
+        args = line.length != 0 ? line.split(' ') : [];
     }
 
     command = args.shift();


### PR DESCRIPTION
This should resolve the issue where lines were parsed incorrectly when there is a `:` inline in the message.
