### PR TITLE
fix command for 'npm start'

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,6 @@
   },
   "subdomain": "nirc",
   "scripts": {
-    "start": "server.js"
+    "start": "node server.js"
   }
 }


### PR DESCRIPTION
don't try to run `bash -c server.js`.  Run `bash -c node server.js` instead.
