### PR TITLE
Fixing name change bug

### DIFF
--- a/lib/irc.js
+++ b/lib/irc.js
@@ -172,7 +172,7 @@ function Client(server, nick, opt) {
 										}
                     self.emit('change_nick', {channel: chanName, oldnick: message.nick, newnick: message.args[0]});
                     self.emit('message', messageToEmit);
-
+		    self.nick = message.args[0];
 										channel.users[message.args[0]] = channel.users[message.nick]
                     delete channel.users[message.nick];
                   }


### PR DESCRIPTION
If you changed nicks then went to a new channel, the server would crash.
