### PR TITLE
limit tabview to 500 lines

### DIFF
--- a/public/javascripts/client.js
+++ b/public/javascripts/client.js
@@ -94,10 +94,10 @@
       tabView.append(newLine)
              .scrollTop(tabView[0].scrollHeight);
 
-      var visibleLines = tabView.find('.line');
+      var visibleLines = tabView.find('.line').toArray();
       while (visibleLines.length > maxLines) {
-        visibleLines.get(0).remove();
-        visibleLines.shift();
+        visibleLines[0].remove();
+        visibleLines.shift(); // in case we use this later in the function
       }
     }
 


### PR DESCRIPTION
For #56. This is a quick and dirty fix; ideally we'd want to have an actual object keeping track of these lines, but since for now all we have is DOM elements, we'll have to run `.find()` on every incoming line.

Also I can't test this because of the "can't set headers" thing, so recommend someone testing before merging.
