### PR TITLE
Make the server password field a "password" field

### DIFF
--- a/src/templates/config.html
+++ b/src/templates/config.html
@@ -35,7 +35,7 @@
 
     <div class="control-group">
       <label for="server_pass">Server Password:</label>
-      <input type="text" name="server_pass" id="server_pass"
+      <input type="password" name="server_pass" id="server_pass"
              ng-model="config.password">
     </div>
 


### PR DESCRIPTION
Not a big deal, but when a user sees a password field, they usually expect the field to hide its input. 
