### PR TITLE
added optional https

### DIFF
--- a/server.js
+++ b/server.js
@@ -1,8 +1,29 @@
 /*
+  Enable HTTPS Webserver
+*/
+
+var ssl = false;
+
+/*
   Dependencies
 */
+if(ssl === true)
+{
+  var express = require('express'),
+      http    = require('https');
+  var fs      = require('fs');
+
+var options = {
+  key: fs.readFileSync('/dir/to/your/keyname.key'),
+  cert: fs.readFileSync('/dir/to/your/cert.crt')
+};
+
+}
+else
+{
 var express = require('express'),
     http    = require('http');
+}
 
 /*
   Initialize & Configure Express
@@ -18,8 +39,14 @@ app.configure(function () {
 /*
   Initialize the Server
 */
+if(ssl === true)
+{
+var server = http.createServer(options,app).listen(process.env.PORT || 3000);
+}
+else
+{
 var server = http.createServer(app).listen(process.env.PORT || 3000);
-
+}
 /*
   Load Main (Loads Socket.io & IRC)
 */


### PR DESCRIPTION
I was using nirc on a subdomain when including on the main domain the content was insecure. 

Edited server.js to include support for https server, you will need to point it towards your key/cert files.

(constructive criticism is very welcome, new to all this)
