### PR TITLE
BUG: /quits causing duplicate lowercased channels to show up in client

### DIFF
--- a/lib/irc.js
+++ b/lib/irc.js
@@ -269,13 +269,14 @@ function Client(server, nick, opt) {
 
                 break;
             case "QUIT":
-                for (var chanName in self.chans) {
-                  var channel = self.chans[chanName];
+                for (var chanKey in self.chans) {
+                  var channel = self.chans[chanKey];
+                  var chanName = channel.serverName;
 
                   if ('string' == typeof channel.users[message.nick]) {
                     messageToEmit.receiver  = chanName;
-                    messageToEmit.message   = '* Quits: ' + message.nick + ' (Message: ' + message.args[0] + ')';
 
+                    messageToEmit.message   = 'Quits: ' + message.nick + ' (Message: ' + message.args[0] + ')';
                     self.emit('message', messageToEmit);
                     self.emit('channel_remove_nick', {channel: chanName, nick: message.nick});
 


### PR DESCRIPTION
Hi there -- Thanks for this great client. Found a small bug that can be reproduced locally by joining as user1 in one browser and user2 in a second browser. When user2 disconnects (msg: /quit), was seeing in user1's client a bug where a duplicate lowercase channel had been created. This was because the channel key was being sent on the quit message rather than the channel's 'serverName' property.
