### PR TITLE
nirc crashes when user enters a command without arguments

### DIFF
--- a/lib/irc.js
+++ b/lib/irc.js
@@ -457,7 +457,7 @@ Client.prototype.send = function(command) { // {{{
     // Remove the command
     args.shift();
 
-    if ( args[args.length-1].match(/\s/) ) {
+    if ( args.length > 0 && args[args.length-1].match(/\s/) ) {
         args[args.length-1] = ":" + args[args.length-1];
     }
 


### PR DESCRIPTION
If you enter `/foo` (I tried `/clear`) the server crashes, here's the output:

```
/[...]/nirc/lib/irc.js:460
    if ( args[args.length-1].match(/\s/) ) {
                             ^
TypeError: Cannot call method 'match' of undefined
```

Checking for array length fixes this:
`if ( args.length > 0 && args[args.length-1].match(/\s/) ) {`
